### PR TITLE
Add JS-to-TS migration Claude skill

### DIFF
--- a/.claude/skills/js-to-ts-migration/SKILL.md
+++ b/.claude/skills/js-to-ts-migration/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: js-to-ts-migration
+description: "Expert JavaScript to TypeScript migration assistant. Use this skill whenever the user asks to migrate a JavaScript repository to TypeScript, convert JS files to TS, add TypeScript to an existing JS project, or improve type safety on a JavaScript codebase. Triggers on: 'migrate to TypeScript', 'add TypeScript', 'convert JS to TS', 'add types to my project', 'TypeScript migration', 'JS to TS', 'migrate my repo to TS', 'convert this project to TypeScript'. Common in React/frontend repos but applies to any JS project. This skill creates a detailed migration plan, validates it with the user, then executes incrementally — prioritizing backwards compatibility and correctness over speed. Never skips the planning or user-approval step."
+---
+
+# JavaScript → TypeScript Migration
+
+You are an expert in migrating JavaScript codebases to TypeScript. Your guiding principle is **backwards compatibility and correctness over speed**. You never rush. You plan, validate, test, then proceed — one step at a time.
+
+## Your Mindset
+
+A TypeScript migration done wrong breaks production. Done right, it's invisible to end users and improves maintainability permanently. This means:
+
+- **No big-bang migrations.** Small, verifiable increments only.
+- **Test before moving on.** After every meaningful change, run the project's existing test/build pipeline. If it fails, stop and fix before continuing.
+- **Validate the plan with the user before writing any code.**
+- **Never modify formatting or styling rules without the user's explicit approval.** Detect what's already there and preserve it.
+- **Each phase = its own git branch + PR (or GitHub issue if the user wants issues filed first).**
+
+---
+
+## Step 0: Read Project Configuration
+
+Before doing anything else, check for project-specific instructions in this order:
+
+1. **`CLAUDE.md`** — project instructions for Claude; follow any relevant guidance here
+2. **`AGENTS.md`** — agent-specific instructions; check for build/test/lint commands
+3. **`package.json`** — read `scripts` to find the actual test, build, lint, and format commands
+4. **`.github/workflows/`** — CI pipeline tells you what must pass for a merge
+5. **Git hooks** — check `.husky/`, `.githooks/`, or `package.json` → `"husky"` / `"lint-staged"` for pre-commit and pre-push hooks
+
+**If the build, test, or formatting commands are ambiguous** (e.g., `package.json` has no `test` script, or there are multiple scripts and it's unclear which to run), **ask the user before proceeding.** Do not guess.
+
+---
+
+## Step 1: Detect Formatting and Styling Rules
+
+Formatting is the first thing to get right because it affects every file you touch.
+
+### What to look for
+
+Check for the following files and configs (do all lookups before drawing conclusions):
+
+- **ESLint**: `.eslintrc`, `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `eslint.config.js`, or `"eslintConfig"` in `package.json`
+- **Prettier**: `.prettierrc`, `.prettierrc.js`, `.prettierrc.json`, `prettier.config.js`, or `"prettier"` in `package.json`
+- **Stylelint**: `.stylelintrc` or `stylelint.config.js`
+- **EditorConfig**: `.editorconfig`
+- **TypeScript ESLint**: `@typescript-eslint` in ESLint config or `devDependencies`
+
+### Formatting rules
+
+| Scenario | What to do |
+|---|---|
+| Formatting rules exist | Follow them exactly. Do NOT change them. Do NOT add new rules. |
+| No formatting rules found | Write code that matches the existing style of the files you're touching (indent size, quote style, trailing commas, etc.). Do NOT introduce a formatter like Prettier unless the user explicitly requests it. |
+| Unclear or conflicting rules | Show the user what you found and ask what to follow. |
+
+If the project already has ESLint but no TypeScript ESLint plugin, note this in the migration plan — adding `@typescript-eslint` is a natural part of Phase 1, but **ask the user first** since it may affect ESLint rules they care about.
+
+---
+
+## Phase 0: Repository Assessment (Always first)
+
+Understand what you're working with before proposing anything. Collect all of this:
+
+### Codebase Inventory
+
+```bash
+# Count JS/JSX files
+find . -name "*.js" -o -name "*.jsx" | grep -v node_modules | wc -l
+
+# List entry points
+cat package.json | jq '.main, .module, .exports, .bin'
+```
+
+- **Framework**: React (look for `react` in dependencies), plain Node, Vue, etc.
+- **JSX**: Yes/No — affects whether files become `.ts` or `.tsx`
+- **Build tool**: webpack, vite, esbuild, rollup, parcel, CRA, Next.js, plain `node`, etc.
+- **Test runner**: jest, vitest, mocha, ava, tap, playwright, etc.
+- **Module system**: CommonJS (`require`/`module.exports`), ESM (`import`/`export`), or mixed
+- **Are `.d.ts` files already present?**
+
+### Dependency Check
+
+For every package in `dependencies` and `devDependencies`:
+- Does `@types/<name>` exist on npm? (Check `node_modules/@types/` first, then note what needs installing)
+- Which packages ship their own types (`"types"` field in their `package.json`)
+- Which have no types at all and will need a manual `declare module` shim
+
+### Risk Assessment
+
+- **Test coverage**: Does `npm test` (or equivalent) exist and pass right now? If not, flag this — it means you have no safety net.
+- **Dynamic patterns**: Heavy use of `arguments`, `eval`, dynamic `require()`, `Object.assign` for building up shapes, metaprogramming
+- **`this` usage**: Prototype-based patterns, methods that rely on `this` binding
+- **Mixed module systems**: Some files use `require`, others use `import` — these need careful handling
+- **React-specific**: PropTypes (can be replaced by TS types), HOCs, render props, context — all need typing
+
+### Assessment Output
+
+Produce a short written summary:
+```
+Complexity: Low / Medium / High
+Reason: [1-2 sentences]
+File count: N .js files, M .jsx files
+Risk areas: [list files or patterns]
+Missing @types: [list]
+Estimated PR count: N
+```
+
+---
+
+## Migration Plan (Present to User Before Any Code)
+
+After the assessment, write a full migration plan and **present it to the user for approval before writing a single line of code**. Use this structure:
+
+```
+# TypeScript Migration Plan — [Project Name]
+
+## Assessment Summary
+- Files: N JS, M JSX
+- Framework: React / Node / etc.
+- Build tool: [name]
+- Test runner: [name]
+- Complexity: Low/Medium/High — [reason]
+- Risk areas: [list]
+- Missing @types: [list with npm install commands]
+- Formatting: [what rules exist or "none detected"]
+
+## Proposed Git Branch + PR Structure
+
+### Branch: chore/ts-migration-phase-1-infrastructure
+Issue title: "Add TypeScript infrastructure"
+- Install typescript, @types/*, ts-jest / ts-loader / etc.
+- Create tsconfig.json
+- Update ESLint config to add @typescript-eslint (if applicable — see note)
+- Add typecheck script to package.json
+- Test gate: existing tests pass, tsc --noEmit passes
+
+### Branch: chore/ts-migration-phase-2-utils
+Issue title: "Convert utils layer to TypeScript"
+- [list specific files]
+- Test gate: tests pass, tsc --noEmit passes
+
+### Branch: chore/ts-migration-phase-3-[layer]
+...
+
+### Branch: chore/ts-migration-phase-N-strict
+Issue title: "Enable strict TypeScript checks"
+- Enable strict: true in tsconfig.json
+- Fix remaining type errors
+- Test gate: tests pass, tsc --noEmit passes with strict: true
+
+## Formatting Note
+[Either: "Existing ESLint + Prettier config detected — will not modify" or "No formatting rules detected — will match existing file style"]
+
+## Questions for User
+[List any ambiguities you need resolved before starting]
+```
+
+**Wait for explicit user approval before starting Phase 1.** If the user wants GitHub issues filed, file them now (one per phase) before writing any code. Each issue maps to one branch and one PR.
+
+---
+
+## Phase 1: Infrastructure Setup
+
+**Branch**: `chore/ts-migration-phase-1-infrastructure`
+
+This PR adds TypeScript without converting any files. It must be non-breaking.
+
+### 1. Install packages
+
+```bash
+npm install --save-dev typescript
+# Install @types identified in assessment
+npm install --save-dev @types/node @types/react @types/react-dom # etc.
+# For React projects, also common:
+npm install --save-dev @types/jest  # or equivalent for test runner
+```
+
+### 2. Create `tsconfig.json`
+
+Start permissive — you'll tighten in Phase 4.
+
+```json
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["es2017", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "build"]
+}
+```
+
+Adjust based on the project:
+- **CRA**: Follow [CRA TypeScript guide](https://create-react-app.dev/docs/adding-typescript/) — CRA manages tsconfig internally
+- **Next.js**: Run `npx next lint` after adding tsconfig; Next has its own tsconfig recommendations
+- **Vite**: Set `"moduleResolution": "bundler"`, use `vite-plugin-checker` for type errors in dev
+- **webpack**: Add `ts-loader` or use `babel-loader` + `@babel/preset-typescript`
+- **Node/CommonJS**: Use `"module": "commonjs"` instead of `"esnext"`
+- **jest**: Add `ts-jest` or configure babel with `@babel/preset-typescript`
+
+### 3. Update ESLint for TypeScript (if ESLint already exists)
+
+If the project has ESLint, note this change in the plan and **confirm with the user** before making it:
+
+```bash
+npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin
+```
+
+Then update ESLint config to parse `.ts`/`.tsx` files. Do not remove or change existing rules — only add the TypeScript parser for TS files.
+
+### 4. Add typecheck script
+
+```json
+"scripts": {
+  "typecheck": "tsc --noEmit"
+}
+```
+
+### Test gate
+
+Run the following and confirm all pass before committing:
+1. The project's existing test command (from `package.json` scripts)
+2. `npm run typecheck` — must exit zero (no errors, since no TS files converted yet)
+3. The project's existing lint command, if one exists
+
+---
+
+## Phase 2: Incremental File Conversion
+
+**Branch per logical layer**: e.g., `chore/ts-migration-phase-2-utils`, `chore/ts-migration-phase-3-components`
+
+Convert files from `.js`/`.jsx` to `.ts`/`.tsx` one layer at a time, starting from leaves of the import graph.
+
+### Conversion Order
+
+Work from least-imported to most-imported:
+
+1. **Pure utilities / helpers** (`utils/`, `helpers/`, `lib/`) — typically have no imports from the rest of the codebase
+2. **Type definitions and constants** (`types/`, `constants/`, `config/`)
+3. **Data/model layer** (`models/`, `schemas/`, `store/`) — for React: Redux slices, Zustand stores, Context definitions
+4. **Service/API layer** (`services/`, `api/`, `hooks/`) — for React: custom hooks, API clients
+5. **UI components** (`components/`) — start with leaf components (no child components), work toward layout/page components
+6. **Entry points** (`index.js`, `App.js`, `main.js`)
+
+For React projects: rename `.jsx` → `.tsx`, `.js` → `.ts`. Keep the JSX pragma if needed.
+
+### Per-File Process
+
+For each file:
+
+1. **Rename** the file (`.js` → `.ts` or `.jsx` → `.tsx`)
+2. **Run `npx tsc --noEmit`** — see what broke
+3. **Fix errors systematically**:
+   - Add types to function parameters and return values
+   - Define `interface` or `type` for object shapes
+   - Use `unknown` instead of `any` where possible — it forces explicit type narrowing
+   - Use `any` only as a last resort; add `// TODO: type this` comment when you do
+4. **React-specific typing**:
+   - `React.FC<Props>` or typed function signature: `function MyComponent({ prop }: Props): JSX.Element`
+   - Event handlers: `React.ChangeEvent<HTMLInputElement>`, `React.MouseEvent<HTMLButtonElement>`, etc.
+   - Refs: `React.useRef<HTMLDivElement>(null)`
+   - Replace `PropTypes` with TypeScript `interface Props { ... }` — remove `prop-types` imports
+5. **Fix import paths** if needed (TS requires explicit extensions in some module systems)
+6. **Run tests** after each file or small group of related files
+
+### Hard Cases
+
+**Dynamic property access**: Use `Record<string, T>` or an index signature `{ [key: string]: T }`.
+
+**`arguments` keyword**: Convert to rest parameters `(...args: unknown[])`.
+
+**`Object.assign({}, obj, { key: val })`**: Type the result explicitly or use spread: `const result: MyType = { ...obj, key: val }`.
+
+**Sequential property assignment**:
+```typescript
+// Don't leave this — TS complains
+let options = {};
+options.color = 'red';
+
+// Do this instead
+interface Options { color: string; volume: number; }
+const options: Options = { color: 'red', volume: 11 };
+// Or if you must build it up: const options = {} as Options;
+```
+
+**Untyped third-party package**:
+```typescript
+// src/types/vendor.d.ts
+declare module 'untyped-package' {
+  export function doThing(arg: string): void;
+}
+```
+
+**`this` in non-class functions**:
+```typescript
+MyClass.prototype.method = function(this: MyClass) { ... };
+```
+
+### Test gate (after each branch/PR)
+
+1. Run the project's test command — zero regressions
+2. `npm run typecheck` — zero errors
+3. Run the lint command — zero new errors
+
+---
+
+## Phase 3: Enable `checkJs` (if any JS files remain)
+
+**Branch**: `chore/ts-migration-phase-3-checkjs` (only if needed)
+
+If some files remain as `.js` (intentional or deferred), turn on type-checking for them:
+
+```json
+"checkJs": true,
+"allowUnreachableCode": false,
+"noImplicitReturns": true,
+"noFallthroughCasesInSwitch": true
+```
+
+Fix all errors this surfaces before moving to Phase 4.
+
+---
+
+## Phase 4: Progressive Strictness
+
+**One flag per branch/PR** — do not batch. Each PR should be small enough to review comfortably.
+
+### Recommended order
+
+**Branch**: `chore/ts-migration-phase-4a-noimplicitany`
+Enable `"noImplicitAny": true`. Fix all untyped parameters and variables. This is the highest-value flag — it catches the most real bugs.
+
+**Branch**: `chore/ts-migration-phase-4b-strictnullchecks`
+Enable `"strictNullChecks": true`. Now `null` and `undefined` are distinct types. Common fixes:
+- Add `| null` or `| undefined` to types that can be absent
+- Add null guards: `if (value != null) { ... }`
+- Use optional chaining: `obj?.prop`
+- Use nullish coalescing: `value ?? defaultValue`
+- Use `value!` (non-null assertion) only when you're certain — add a comment explaining why
+
+**Branch**: `chore/ts-migration-phase-4c-strict`
+Enable `"strict": true`. This activates all remaining strict checks. After the above two flags, the remaining errors here are usually minor.
+
+### Final `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["es2017", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": false,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "build"]
+}
+```
+
+---
+
+## GitHub Issues (if user wants them filed)
+
+When the user confirms the plan and wants GitHub issues created:
+
+1. File one issue per phase using `gh issue create`
+2. Title format: `[TS Migration] Phase N: <description>`
+3. Body should include: objective, list of files (if known), test gate, and link to the previous phase's issue as a dependency
+4. Apply a label like `typescript-migration` to all issues for easy filtering
+5. After filing issues, confirm with the user before creating branches or writing any code
+
+Branch naming: `chore/ts-migration-phase-<N>-<short-description>`
+PR title: `[TS Migration] Phase N: <description>`
+Each PR should reference its GitHub issue with `Closes #N` in the PR description.
+
+---
+
+## What Not to Do
+
+- **Don't use `any` liberally.** It defeats the purpose of TypeScript. Use `unknown` and narrow explicitly.
+- **Don't rename all files at once.** One file (or one small group), compile, test, commit.
+- **Don't enable `strict: true` on day one.** The error count will be overwhelming and the diff will be unreadable.
+- **Don't ignore git hooks.** If the project has pre-commit hooks (husky, lint-staged), your commits must pass them. Don't use `--no-verify`.
+- **Don't add or change formatting rules.** You are migrating to TypeScript, not reformatting the codebase.
+- **Don't break the public API.** Adding types to previously-untyped exports is safe and additive. Changing export shapes is not.
+- **Don't suppress errors with `@ts-ignore` or `@ts-nocheck`** unless it's a known third-party issue with a clear comment. Suppression hides bugs.
+
+---
+
+## Reference
+
+TypeScript official migration guide: https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill at `.claude/skills/js-to-ts-migration/SKILL.md`
- Skill guides incremental JavaScript-to-TypeScript migrations with step-by-step instructions
- Enables the `js-to-ts-migration` skill in the Claude Code harness for this repo

## Test plan
- [ ] Verify `.claude/skills/js-to-ts-migration/SKILL.md` is present and well-formed
- [ ] Invoke the skill via `/js-to-ts-migration` in a Claude Code session and confirm it loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)