### PR TITLE
[CLAUDE.md] Update to reflect post-migration stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,35 +5,41 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm start          # Start dev server at localhost:3000
-npm run build      # Production build
-npm test           # Run tests (Jest + React Testing Library)
-npm run deploy     # Build + deploy to GitHub Pages (GeoffA12.github.io/portfolio-pages)
+npm start           # Start dev server at localhost:3000 (Vite)
+npm run build       # Production build (runs typecheck + lint + format:check first)
+npm run preview     # Preview production build locally
+npm test            # Run tests (Vitest + React Testing Library)
+npm run typecheck   # TypeScript type-check without emitting
+npm run lint        # ESLint (src/)
+npm run lint:fix    # ESLint with auto-fix
+npm run format      # Prettier write
+npm run format:check  # Prettier check (CI)
+npm run deploy      # Build + deploy to GitHub Pages (GeoffA12.github.io/portfolio-pages)
 ```
 
 To run a single test file:
 ```bash
-npm test -- --testPathPattern=<filename>
+npx vitest run src/path/to/File.test.tsx
 ```
 
 ## Architecture
 
-This is a React 16 single-page portfolio site deployed to GitHub Pages. Routing uses `react-router-dom` v5 with the base path `/portfolio-pages`.
+This is a **React 18** single-page portfolio site built with **Vite**, fully written in **TypeScript**, deployed to GitHub Pages. Routing uses `react-router-dom` v7.
 
-**Routes** (defined in `src/App.js`):
-- `/portfolio-pages` → `Landing`
+**Routes** (defined in `src/App.tsx`):
+- `/` → `Landing`
 - `/aboutMe` → `AboutMe`
 - `/experience` → `Experience`
 
-**Shared styling** lives in `src/common/styles/SharedStyles.js` — a `makeStyles` hook (`sharedStyles`) exporting reusable MUI class names (`headerText`, `headerTextContainer`, `paperTextContainer`, `paperText`). Always import this rather than duplicating styles.
+**Shared styling** lives in `src/common/styles/SharedStyles.ts` — exports named `SxProps<Theme>` constants (`headerTextContainerSx`, `paperTextContainerSx`, `headerTextSx`, `paperTextSx`). Always import these rather than duplicating `sx` props.
 
 **Component hierarchy for the Experience page:**
 - `Experience` — owns the data arrays and calls `normalizeProjectImageData()` to chunk them into rows of 3
 - `CardRow` — renders a row, switches between `ProjectCard` (clickable image + label) and `ExperienceCard` (tech logo grid) based on `cardType` prop
 
-**Styling approach:** Material UI v4 (`@material-ui/core`) with `makeStyles`/`useStyles` throughout. No CSS modules or styled-components. Color palette centers on `#324a54` (dark teal card backgrounds). Font families are `Quicksand` (headings) and `Roboto` (body).
+**Styling approach:** **MUI v5** (`@mui/material` + `@emotion`) with the `sx` prop throughout. No CSS modules, styled-components, or `makeStyles`. Color palette centers on `#324a54` (dark teal card backgrounds). Font families are `Quicksand` (headings) and `Roboto` (body).
 
-**Navigation:** `PrimaryAppBar` (`src/common/components/PrimaryAppBar.js`) renders a persistent top bar with a drawer (`MenuButton`) for page navigation and a home `IconButton` linking to `/portfolio-pages`.
+**Navigation:** `PrimaryAppBar` (`src/common/components/PrimaryAppBar.tsx`) renders a persistent top bar with a drawer (`MenuButton`) for page navigation and a home `IconButton` linking to `/`.
 
 ## Agent skills
 


### PR DESCRIPTION
## Summary

Closes #24

- Updated React version (16 → 18) and build tool (CRA → Vite)
- Updated `react-router-dom` v5 → v7; corrected route paths (removed `/portfolio-pages` base prefix)
- Updated MUI v4 (`@material-ui/core` + `makeStyles`) → MUI v5 (`@mui/material` + `sx` prop / `SxProps<Theme>`)
- Updated `SharedStyles` description: now exports named `SxProps<Theme>` constants, not a `makeStyles` hook
- Updated all `.js` file references to `.tsx`/`.ts`
- Fixed single-file test command: `--testPathPattern` (Jest) → `npx vitest run`
- Added missing commands: `typecheck`, `lint`, `lint:fix`, `format`, `format:check`, `preview`
- Noted that `npm run build` has a `prebuild` step

## Test plan

- [ ] Verify all documented commands run successfully
- [ ] Confirm route paths match `src/App.tsx`
- [ ] Confirm `SharedStyles.ts` exports match documented constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)